### PR TITLE
add timeout for compilation and execution

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -4,11 +4,17 @@ pub const UUID_SHOULD_BE_VALID_STR: &str = "a uuid should always be valid utf8 e
 
 /// An error that occurs in relation to checking a solution.
 #[derive(Debug, Error)]
-pub enum CheckError {
+pub enum SubmissionError {
     /// This error is often in relation to creating, reading from or writing to files and directories.
     #[error("an error occured during an IO interaction")]
     IOInteraction,
 
     #[error("an error occured during compilation: {0}")]
     Compilation(String),
+
+    #[error("a timeout happened during compilation")]
+    CompileTimeout,
+
+    #[error("a timeout happened during execution")]
+    ExecuteTimeout,
 }

--- a/src/runner/haskell.rs
+++ b/src/runner/haskell.rs
@@ -83,7 +83,12 @@ impl LanguageHandler for Haskell {
         let test_file_str = test_file_path.to_str().expect(UUID_SHOULD_BE_VALID_STR);
 
         let Ok(compile_output) = Command::new("ghc")
-            .args(["-O2", "-o", executable_str, test_file_str])
+            .args([
+                "-O2",          // highest safe level of optimization (ensures same semantics)
+                "-o",           // specifies the output path of the binary
+                executable_str, // the output path of the binary
+                test_file_str,  // the compilation target
+            ])
             .output()
         else {
             return Err(CheckError::IOInteraction);

--- a/src/runner/haskell.rs
+++ b/src/runner/haskell.rs
@@ -1,9 +1,14 @@
 use super::LanguageHandler;
 use crate::{
-    error::{CheckError, UUID_SHOULD_BE_VALID_STR},
+    error::{SubmissionError, UUID_SHOULD_BE_VALID_STR},
     model::{Parameter, TestCase},
+    timeout::timeout_process,
 };
-use std::{path::PathBuf, process::Command};
+use std::{
+    path::PathBuf,
+    process::{Command, Stdio},
+    time::Duration,
+};
 
 const HASKELL_BASE_TEST_CODE: &str = r###"
 SOLUTION
@@ -75,36 +80,66 @@ impl LanguageHandler for Haskell {
         }
     }
 
-    fn run(&self) -> Result<(), CheckError> {
+    async fn run(&self) -> Result<(), SubmissionError> {
         let mut executable_path = self.temp_dir.clone();
         executable_path.push("/test");
         let executable_str = executable_path.to_str().expect(UUID_SHOULD_BE_VALID_STR);
         let test_file_path = self.test_file_path();
         let test_file_str = test_file_path.to_str().expect(UUID_SHOULD_BE_VALID_STR);
 
-        let Ok(compile_output) = Command::new("ghc")
+        let Ok(compile_process) = Command::new("ghc")
             .args([
                 "-O2",          // highest safe level of optimization (ensures same semantics)
                 "-o",           // specifies the output path of the binary
                 executable_str, // the output path of the binary
                 test_file_str,  // the compilation target
             ])
-            .output()
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
         else {
-            return Err(CheckError::IOInteraction);
+            return Err(SubmissionError::IOInteraction);
         };
 
-        let Ok(stderr) = String::from_utf8(compile_output.stderr) else {
-            // this should probably not be an io interaction, and possibly may never occur
-            return Err(CheckError::IOInteraction);
-        };
+        let (compile_exit_status, compile_output) =
+            timeout_process(Duration::from_secs(5), compile_process)
+                .await?
+                .ok_or(SubmissionError::CompileTimeout)?;
 
-        if stderr.contains("error:") {
-            return Err(CheckError::Compilation(stderr));
+        match compile_exit_status
+            .code()
+            .expect("ghc should always return exit status code")
+        {
+            // 0 means success
+            0 => {
+                // if we want to return warnings from successful compilations
+                // then this is the place to check stderr
+            }
+            // 1 means compilation error
+            1 => match String::from_utf8(compile_output.stderr) {
+                Ok(stderr) => return Err(SubmissionError::Compilation(stderr)),
+                // may never occur, and should not be this error type anyhow
+                Err(_) => return Err(SubmissionError::IOInteraction),
+            },
+            // not correct error type
+            unknown => return Err(SubmissionError::IOInteraction), // internal
         }
 
-        if Command::new(executable_path).output().is_err() {
-            return Err(CheckError::IOInteraction);
+        let Ok(execution_handle) = Command::new(executable_path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+        else {
+            return Err(SubmissionError::IOInteraction);
+        };
+
+        if timeout_process(Duration::from_secs(5), execution_handle)
+            .await?
+            .is_none()
+        {
+            return Err(SubmissionError::ExecuteTimeout);
         }
 
         Ok(())

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -5,8 +5,6 @@ use std::{
 };
 use tokio::time::{sleep, Instant};
 
-const GUARDED_EXPECT_DUE_TO_IF_CONDITION: &str = "guarded expect due to if condition";
-
 pub async fn timeout_process(
     timeout: Duration,
     mut process: Child,
@@ -21,7 +19,7 @@ pub async fn timeout_process(
         Ok(Some(exit_status)) => {
             let output = process
                 .wait_with_output()
-                .expect(GUARDED_EXPECT_DUE_TO_IF_CONDITION);
+                .expect("guarded expect due to if condition");
             Ok(Some((exit_status, output)))
         }
         Ok(None) => {

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -1,0 +1,34 @@
+use crate::error::SubmissionError;
+use std::{
+    process::{Child, ExitStatus, Output},
+    time::Duration,
+};
+use tokio::time::{sleep, Instant};
+
+const GUARDED_EXPECT_DUE_TO_IF_CONDITION: &str = "guarded expect due to if condition";
+
+pub async fn timeout_process(
+    timeout: Duration,
+    mut process: Child,
+) -> Result<Option<(ExitStatus, Output)>, SubmissionError> {
+    let start = Instant::now();
+
+    while process.try_wait().is_ok_and(|es| es.is_none()) && start.elapsed() < timeout {
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    match process.try_wait() {
+        Ok(Some(exit_status)) => {
+            let output = process
+                .wait_with_output()
+                .expect(GUARDED_EXPECT_DUE_TO_IF_CONDITION);
+            Ok(Some((exit_status, output)))
+        }
+        Ok(None) => {
+            process.kill().expect("should be able to kill child");
+            Ok(None)
+        }
+        // this is in a scenario where the process never started
+        Err(_) => Err(SubmissionError::IOInteraction),
+    }
+}


### PR DESCRIPTION
## Description

adds a 5 seconds timeout to the compilation and execution process of haskell

### Resolved Issue
Fixes #14, although this originally only covered execution it was expanded to also cover compilation

## Changes

- adds a `timeout_process` function which all supported languages can use in the future
- applies this timeout function to haskell
- makes minor changes to the error and response types which will be expanded upon in the future

## Checklist

- [ ] I have added test cases for my additions
- [x] New and old tests passed
- [ ] Documentation is updated
