### PR TITLE
fix json indentation and improve some error responses

### DIFF
--- a/.bruno/bruno.json
+++ b/.bruno/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": ".bruno",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/.bruno/compilation error.bru
+++ b/.bruno/compilation error.bru
@@ -1,0 +1,50 @@
+meta {
+  name: compilation error
+  type: http
+  seq: 4
+}
+
+post {
+  url: http://localhost:8080/submit
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "solution": "solution x =\n  if x < 0\n    then x\n",
+    "testCases": [
+      {
+        "id": 0,
+        "inputParameters": [
+          {
+            "valueType": "integer",
+            "value": "-5"
+          }
+        ],
+        "outputParameters": [
+          {
+            "valueType": "integer",
+            "value": "5"
+          }
+        ]
+      },
+      {
+        "id": 1,
+        "inputParameters": [
+          {
+            "valueType": "integer",
+            "value": "5"
+          }
+        ],
+        "outputParameters": [
+          {
+            "valueType": "integer",
+            "value": "5"
+          }
+        ]
+      }
+    ]
+  }
+  
+}

--- a/.bruno/execution timeout.bru
+++ b/.bruno/execution timeout.bru
@@ -1,0 +1,49 @@
+meta {
+  name: execution timeout
+  type: http
+  seq: 1
+}
+
+post {
+  url: http://localhost:8080/submit
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "solution": "solution x = solution x",
+    "testCases": [
+      {
+        "id": 0,
+        "inputParameters": [
+          {
+            "valueType": "integer",
+            "value": "-5"
+          }
+        ],
+        "outputParameters": [
+          {
+            "valueType": "integer",
+            "value": "5"
+          }
+        ]
+      },
+      {
+        "id": 1,
+        "inputParameters": [
+          {
+            "valueType": "integer",
+            "value": "5"
+          }
+        ],
+        "outputParameters": [
+          {
+            "valueType": "integer",
+            "value": "5"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.bruno/failure, wrong answer.bru
+++ b/.bruno/failure, wrong answer.bru
@@ -1,0 +1,50 @@
+meta {
+  name: failure, wrong answer
+  type: http
+  seq: 3
+}
+
+post {
+  url: http://localhost:8080/submit
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "solution": "solution x =\n  if x < 0\n    then x\n    else x",
+    "testCases": [
+      {
+        "id": 0,
+        "inputParameters": [
+          {
+            "valueType": "integer",
+            "value": "-5"
+          }
+        ],
+        "outputParameters": [
+          {
+            "valueType": "integer",
+            "value": "5"
+          }
+        ]
+      },
+      {
+        "id": 1,
+        "inputParameters": [
+          {
+            "valueType": "integer",
+            "value": "5"
+          }
+        ],
+        "outputParameters": [
+          {
+            "valueType": "integer",
+            "value": "5"
+          }
+        ]
+      }
+    ]
+  }
+  
+}

--- a/.bruno/pass.bru
+++ b/.bruno/pass.bru
@@ -1,0 +1,50 @@
+meta {
+  name: pass
+  type: http
+  seq: 2
+}
+
+post {
+  url: http://localhost:8080/submit
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "solution": "solution x =\n  if x < 0\n    then x * (-1)\n    else x",
+    "testCases": [
+      {
+        "id": 0,
+        "inputParameters": [
+          {
+            "valueType": "integer",
+            "value": "-5"
+          }
+        ],
+        "outputParameters": [
+          {
+            "valueType": "integer",
+            "value": "5"
+          }
+        ]
+      },
+      {
+        "id": 1,
+        "inputParameters": [
+          {
+            "valueType": "integer",
+            "value": "5"
+          }
+        ],
+        "outputParameters": [
+          {
+            "valueType": "integer",
+            "value": "5"
+          }
+        ]
+      }
+    ]
+  }
+  
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use thiserror::Error;
 
 pub const UUID_SHOULD_BE_VALID_STR: &str = "a uuid should always be valid utf8 encoding";
@@ -12,9 +14,9 @@ pub enum SubmissionError {
     #[error("an error occured during compilation: {0}")]
     Compilation(String),
 
-    #[error("a timeout happened during compilation")]
-    CompileTimeout,
+    #[error("compilation exceeded the timeout limit of {0:?}")]
+    CompileTimeout(Duration),
 
-    #[error("a timeout happened during execution")]
-    ExecuteTimeout,
+    #[error("execution exceeded the timeout limit of {0:?}")]
+    ExecuteTimeout(Duration),
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -32,11 +32,12 @@ pub struct Parameter {
 #[derive(Serialize)]
 pub struct TestCaseResult {
     pub id: u64,
-    #[serde(rename = "testResult")]
+    #[serde(rename = "testResult", flatten)]
     pub test_result: TestResult,
 }
 
 #[derive(Serialize, PartialEq)]
+#[serde(tag = "testResult")]
 pub enum TestResult {
     /// The test case passed.
     #[serde(rename = "pass")]
@@ -55,6 +56,7 @@ pub enum TestResult {
 
 /// The reason why a given test case failed.
 #[derive(Serialize, PartialEq)]
+#[serde(tag = "cause", content = "details")]
 pub enum TestCaseFailureReason {
     /// The answer to the test case was incorrect.
     #[serde(rename = "wrongAnswer")]

--- a/src/runner/haskell.rs
+++ b/src/runner/haskell.rs
@@ -10,6 +10,8 @@ use std::{
     time::Duration,
 };
 
+const TIMEOUT: Duration = Duration::from_secs(5);
+
 const HASKELL_BASE_TEST_CODE: &str = r###"
 SOLUTION
 
@@ -102,10 +104,9 @@ impl LanguageHandler for Haskell {
             return Err(SubmissionError::IOInteraction);
         };
 
-        let (compile_exit_status, compile_output) =
-            timeout_process(Duration::from_secs(5), compile_process)
-                .await?
-                .ok_or(SubmissionError::CompileTimeout)?;
+        let (compile_exit_status, compile_output) = timeout_process(TIMEOUT, compile_process)
+            .await?
+            .ok_or(SubmissionError::CompileTimeout(TIMEOUT))?;
 
         match compile_exit_status
             .code()
@@ -141,11 +142,8 @@ impl LanguageHandler for Haskell {
             return Err(SubmissionError::IOInteraction);
         };
 
-        if timeout_process(Duration::from_secs(5), execution_handle)
-            .await?
-            .is_none()
-        {
-            return Err(SubmissionError::ExecuteTimeout);
+        if timeout_process(TIMEOUT, execution_handle).await?.is_none() {
+            return Err(SubmissionError::ExecuteTimeout(TIMEOUT));
         }
 
         Ok(())

--- a/src/runner/haskell.rs
+++ b/src/runner/haskell.rs
@@ -118,7 +118,13 @@ impl LanguageHandler for Haskell {
             }
             // 1 means compilation error
             1 => match String::from_utf8(compile_output.stderr) {
-                Ok(stderr) => return Err(SubmissionError::Compilation(stderr)),
+                Ok(stderr) => {
+                    let mut temp_dir = self.temp_dir.clone();
+                    temp_dir.push("");
+                    let path = temp_dir.to_str().expect(UUID_SHOULD_BE_VALID_STR);
+                    let stripped = stderr.replace(path, "");
+                    return Err(SubmissionError::Compilation(stripped));
+                }
                 // may never occur, and should not be this error type anyhow
                 Err(_) => return Err(SubmissionError::IOInteraction),
             },


### PR DESCRIPTION
## Description

To make the JSON responses structure more coherent and intuitive.

### Resolved Issue
Fixes #19 

## Changes
- change the structure of json responses to better fit a standard format
- include the timeout limit exceeded in compilation and execution timeouts

## Checklist

- [ ] I have added test cases for my additions
- [x] New and old tests passed
- [ ] Documentation is updated
