### PR TITLE
add integration test cases

### DIFF
--- a/.github/workflows/job.yml
+++ b/.github/workflows/job.yml
@@ -48,7 +48,7 @@ jobs:
           shared-key: "workflow"
 
       - name: Run test cases
-        run: cargo test --target=x86_64-unknown-linux-musl --features haskell
+        run: cargo test --target=x86_64-unknown-linux-musl --features haskell --features ci
 
   format:
     name: Formatting

--- a/.github/workflows/job.yml
+++ b/.github/workflows/job.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
+      - name: Install GHC for runtime
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: '9.8.2'
+
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,9 +256,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -368,6 +368,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "serde",
+ "serde_json",
  "thiserror",
  "time",
  "tokio",
@@ -592,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [features]
 default = []
 haskell = []
+ci = []
 
 [dependencies]
 axum = "0.7.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ uuid = { version = "1.11.0", features = ["fast-rng", "v4"] }
 
 [dev-dependencies]
 tower = { version = "0.5.1", features = ["util"] }
+serde_json = "1.0.132"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Here, the `{{LANGUAGE}}` refers to the language instance you want to enable, for
 
 Depending on how you installed your language compiler/interpreter, you may need to run mozart as a super user, to access its dependencies.
 
+During development you can change the log level via the `MOZART_LOG` environment variable - it is set to `info` by default.
+
 # Adding a Language
 
 Mozart is designed to relatively easily support a new language. You need to:

--- a/README.md
+++ b/README.md
@@ -1,55 +1,53 @@
-Look in the justfile for specific commands, alternatively look below - although below may be outdated.
+Mozart is a test composer and runner. It is designed to support any language that has a language handler implemented.
 
-# Docker
+It checks a submitted program against a set of test cases, and reports back the result of this check.
 
-To build image:
+# Why Rust?
+
+Mozart is intended to be deployed inside a linux container and to be as small as possible, so as to not take ressources from the work it is doing.
+
+As such, a couple of requirements were specified:
+
+- **minimal overhead**: because mozart deals with compiling and running programs, with mozart just being an interface, it should be minimal and not take up a lot of space or ressources
+- **compile to statically linked binary**: for ease of deployment, it is nice to compile to a statically linked binary and not thing about it further
+
+Because of the first requirement, languages that require an interpreter or a large runtime were discarded.
+
+And due to the second requirement the option was between Golang and Rust, although other languages of course fulfill both requirements
+
+Golang was considered initially, but was later replaced by Rust due to developer experience and comfort.
+
+Rust also allowed the language support to be enabled as a compile time feature, thereby ensuring that exactly one language is enabled for mozart to compile.
+Furthermore, it also means that even if hundreds of languages are supported, only one is enabled and part of the binary, thereby limiting the binary size.
+
+It is also important to note that performance was not a requirement or consideration, as the bottleneck is compiling and executing the submitted program, not the mozart code.
+
+# Requirements
+
+To run mozart you require:
+
+- the rust compiler (with the `x86_64-unknown-linux-musl` target installed for statically linked binary)
+- the compiler/interpreter of the language you wish to run
+
+# Run
+
+To run mozart you can use the following command:
+
 ```
-docker build -t ghc-instance .
+cargo run --locked --release --target=x86_64-unknown-linux-musl --features {{LANGUAGE}}
 ```
 
-To run the container:
-```
-docker run -p 8080:8080 -d ghc-instance
-```
+Here, the `{{LANGUAGE}}` refers to the language instance you want to enable, for example `haskell`.
 
-# Example Json
-Following JSON will compile correctly and return passed test cases.
-This is only temporary and will return more complete response in the future.
+Depending on how you installed your language compiler/interpreter, you may need to run mozart as a super user, to access its dependencies.
 
-```json
-{
-  "solution": "solution x =\n  if x < 0\n    then x * (-1)\n    else x",
-  "testCases": [
-    {
-      "id": 0,
-      "inputParameters": [
-        {
-          "valueType": "integer",
-          "value": "-5"
-        }
-      ],
-      "outputParameters": [
-        {
-          "valueType": "integer",
-          "value": "5"
-        }
-      ]
-    },
-    {
-      "id": 1,
-      "inputParameters": [
-        {
-          "valueType": "integer",
-          "value": "5"
-        }
-      ],
-      "outputParameters": [
-        {
-          "valueType": "integer",
-          "value": "5"
-        }
-      ]
-    }
-  ]
-}
-```
+# Adding a Language
+
+Mozart is designed to relatively easily support a new language. You need to:
+
+- add a language feature to the `Cargo.toml` for the language you wish to support
+- create a new module inside `src/runner` named after the language
+- implement the `LanguageHandler` trait for your language handler
+- add you language handler as a conditional field (based on language feature) to the `TestRunner` in `src/runner/mod.rs`
+
+You can look at the existing supported languages for an idea of how it should look.

--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ run LANGUAGE:
 
 # Run test cases
 test LANGUAGE:
-    cargo test -q {{PLATFORM}} --features {{LANGUAGE}}
+    cargo test {{PLATFORM}} --features {{LANGUAGE}}
 
 # Build the mozart image
 dbuild LANGUAGE:

--- a/justfile
+++ b/justfile
@@ -5,13 +5,11 @@ default:
 
 # Build and execute crate
 dev LANGUAGE:
-    MOZART_LOG=TRACE cargo build --locked --release {{PLATFORM}} --features {{LANGUAGE}}
-    ./target/x86_64-unknown-linux-musl/release/mozart
+    MOZART_LOG=TRACE cargo run --locked --release {{PLATFORM}} --features {{LANGUAGE}}
 
 # Build and execute crate
 run LANGUAGE:
-    cargo build --locked --release {{PLATFORM}} --features {{LANGUAGE}}
-    ./target/x86_64-unknown-linux-musl/release/mozart
+    cargo run --locked --release {{PLATFORM}} --features {{LANGUAGE}}
 
 # Run test cases
 test LANGUAGE:

--- a/justfile
+++ b/justfile
@@ -4,23 +4,23 @@ default:
     just -l
 
 # Build and execute crate
-dev TARGET:
-    MOZART_LOG=TRACE cargo build --locked --release {{PLATFORM}} --features {{TARGET}}
+dev LANGUAGE:
+    MOZART_LOG=TRACE cargo build --locked --release {{PLATFORM}} --features {{LANGUAGE}}
     ./target/x86_64-unknown-linux-musl/release/mozart
 
 # Build and execute crate
-run TARGET:
-    cargo build --locked --release {{PLATFORM}} --features {{TARGET}}
+run LANGUAGE:
+    cargo build --locked --release {{PLATFORM}} --features {{LANGUAGE}}
     ./target/x86_64-unknown-linux-musl/release/mozart
 
 # Run test cases
-test TARGET:
-    cargo test -q {{PLATFORM}} --features {{TARGET}}
+test LANGUAGE:
+    cargo test -q {{PLATFORM}} --features {{LANGUAGE}}
 
 # Build the mozart image
-dbuild TARGET:
-    docker build . -t {{TARGET}} -f docker/{{TARGET}}
+dbuild LANGUAGE:
+    docker build . -t {{LANGUAGE}} -f docker/{{LANGUAGE}}
 
 # Runs the mozart container
-drun TARGET:
-    docker run -p 8080:8080 -d {{TARGET}}
+drun LANGUAGE:
+    docker run -p 8080:8080 -d {{LANGUAGE}}

--- a/justfile
+++ b/justfile
@@ -24,3 +24,7 @@ dbuild LANGUAGE:
 # Runs the mozart container
 drun LANGUAGE:
     docker run -p 8080:8080 -d {{LANGUAGE}}
+
+# Compile and open documentation.
+doc LANGUAGE="default":
+    cargo doc --open --document-private-items --features {{LANGUAGE}}

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 pub const UUID_SHOULD_BE_VALID_STR: &str = "a uuid should always be valid utf8 encoding";
 
 /// An error that occurs in relation to checking a submission.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub enum SubmissionError {
     /// Some sort of internal error occured.
     ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,7 +23,7 @@ pub enum SubmissionError {
     /// There was an error during the compilation of the submitted solution.
     ///
     /// The provided `String` should contain the underlying compilation error.
-    #[error("an error occured during compilation: {0}")]
+    #[error("an error occurred during compilation: {0}")]
     Compilation(String),
 
     /// The compilation process exceeded the set timeout, and was therefore stopped prematurely.

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,6 +192,23 @@ mod haskell {
     use tower::ServiceExt;
 
     #[tokio::test]
+    async fn invalid_http_method() {
+        let mozart = app();
+        let expected_status_code = StatusCode::METHOD_NOT_ALLOWED;
+        let request = Builder::new()
+            .method(Method::GET)
+            .uri("/submit")
+            .body(Body::empty())
+            .expect("failed to build request");
+
+        let actual = mozart
+            .oneshot(request)
+            .await
+            .expect("failed to await oneshot");
+
+        assert_eq!(actual.status(), expected_status_code);
+    }
+    #[tokio::test]
     async fn solution_with_all_data_types_as_input() {
         let mozart = app();
         let solution = [

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ fn app() -> Router {
         .layer(
             TraceLayer::new_for_http().make_span_with(|_: &Request<Body>| {
                 let request_id = Uuid::new_v4();
-                info_span!("request", %request_id)
+                info_span!("", %request_id)
             }),
         )
 }
@@ -79,7 +79,7 @@ async fn submit(Json(submission): Json<Submission>) -> SubmissionResult {
     debug!(?submission);
 
     let temp_dir = PathBuf::from(format!("{}/{}", PARENT_DIR, uuid));
-    info!("request unique directory: {:?}", temp_dir);
+    info!("unique directory: {:?}", temp_dir);
 
     if let Err(err) = fs::create_dir(temp_dir.as_path()) {
         error!("could not create temporary working directory: {}", err);

--- a/src/main.rs
+++ b/src/main.rs
@@ -245,6 +245,27 @@ mod haskell {
 
         assert_eq!(actual.status(), expected_status_code);
     }
+
+    #[tokio::test]
+    async fn invalid_json() {
+        let mozart = app();
+        let expected_status_code = StatusCode::UNPROCESSABLE_ENTITY;
+        let body = serde_json::to_string(&ParameterType::Int).expect("failed to serialize body");
+        let request = Builder::new()
+            .method(Method::POST)
+            .header("Content-Type", "application/json")
+            .uri("/submit")
+            .body(body)
+            .expect("failed to build request");
+
+        let actual = mozart
+            .oneshot(request)
+            .await
+            .expect("failed to await oneshot");
+
+        assert_eq!(actual.status(), expected_status_code);
+    }
+
     #[tokio::test]
     async fn solution_with_all_data_types_as_input() {
         let mozart = app();

--- a/src/main.rs
+++ b/src/main.rs
@@ -467,7 +467,7 @@ mod haskell {
     #[tokio::test]
     async fn compile_timeout() {
         let mozart = app();
-        let repeated = "  + x\n".repeat(10000);
+        let repeated = "  + x\n".repeat(20000);
         let solution = [
             "solution :: Int -> Int",
             "solution x =",

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,8 +175,8 @@ mod haskell {
     // - all test cases wrong answer (for all data types)
     // - runtime error in no last test case
     // - solution with multiple different data types as input (possibly one with all different data types, like a string creation exercise or something) +
-    // - solution with multiple different data types as output
     // - compilation error
+    // - solution with multiple different data types as output +
     // - timeout error on execution (i think compilation is impossible to check unfortunately)
     // - mix of pass and fail test cases + runtime error at some point
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,7 +173,7 @@ mod haskell {
     // example integration test cases
     // - all test cases pass (for all data types)
     // - all test cases wrong answer (for all data types)
-    // - runtime error in no last test case
+    // - runtime error in non last test case
     // - solution with multiple different data types as input (possibly one with all different data types, like a string creation exercise or something) +
     // - solution with multiple different data types as output +
     // - compilation error +

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,8 +175,8 @@ mod haskell {
     // - all test cases wrong answer (for all data types)
     // - runtime error in no last test case
     // - solution with multiple different data types as input (possibly one with all different data types, like a string creation exercise or something) +
-    // - compilation error
     // - solution with multiple different data types as output +
+    // - compilation error +
     // - timeout error on execution (i think compilation is impossible to check unfortunately)
     // - mix of pass and fail test cases + runtime error at some point
 
@@ -321,5 +321,75 @@ mod haskell {
 
         assert_eq!(actual_status, expected_status);
         assert_eq!(actual_body, expected_body);
+    }
+
+    #[tokio::test]
+    async fn compilation_error() {
+        let mozart = app();
+        let solution = [
+            "solution :: Int -> Int",
+            "solution x =",
+            "  if x < 0",
+            "    then x * (-1)",
+            // "    else x",
+        ]
+        .join("\n");
+        let test_cases = Box::new([
+            TestCase {
+                id: 0,
+                input_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Int,
+                    value: String::from("10"),
+                }]),
+                output_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Int,
+                    value: String::from("10"),
+                }]),
+            },
+            TestCase {
+                id: 0,
+                input_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Int,
+                    value: String::from("-10"),
+                }]),
+                output_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Int,
+                    value: String::from("10"),
+                }]),
+            },
+        ]);
+        let submission = Submission {
+            solution,
+            test_cases,
+        };
+        let body = serde_json::to_string(&submission).expect("failed to serialize submission");
+        let request = Builder::new()
+            .header("Content-Type", "application/json")
+            .method(Method::POST)
+            .uri("/submit")
+            .body(Body::from(body))
+            .expect("failed to build request");
+        let expected_status = StatusCode::OK;
+
+        let actual = mozart
+            .oneshot(request)
+            .await
+            .expect("failed to execute oneshot request");
+
+        let actual_status = actual.status();
+        let body_bytes = to_bytes(actual.into_body(), usize::MAX)
+            .await
+            .expect("failed to convert body to bytes");
+
+        let actual_body: SubmissionResult =
+            serde_json::from_slice(&body_bytes).expect("failed to deserialize response body");
+
+        assert_eq!(actual_status, expected_status);
+
+        if let SubmissionResult::Error(err) = actual_body {
+            assert!(err.starts_with("an error occurred during compilation:"));
+        } else {
+            panic!("response body was not of error variant");
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -417,7 +417,7 @@ mod haskell {
                 }]),
             },
             TestCase {
-                id: 0,
+                id: 1,
                 input_parameters: Box::new([Parameter {
                     value_type: ParameterType::Int,
                     value: String::from("-10"),
@@ -488,7 +488,7 @@ mod haskell {
                 }]),
             },
             TestCase {
-                id: 0,
+                id: 1,
                 input_parameters: Box::new([Parameter {
                     value_type: ParameterType::Int,
                     value: String::from("-10"),
@@ -552,7 +552,7 @@ mod haskell {
                 }]),
             },
             TestCase {
-                id: 0,
+                id: 1,
                 input_parameters: Box::new([Parameter {
                     value_type: ParameterType::Int,
                     value: String::from("-10"),
@@ -615,7 +615,7 @@ mod haskell {
                 }]),
             },
             TestCase {
-                id: 0,
+                id: 1,
                 input_parameters: Box::new([Parameter {
                     value_type: ParameterType::Int,
                     value: String::from("5"),
@@ -674,7 +674,7 @@ mod haskell {
                 }]),
             },
             TestCase {
-                id: 0,
+                id: 1,
                 input_parameters: Box::new([Parameter {
                     value_type: ParameterType::Bool,
                     value: String::from("false"),
@@ -733,7 +733,7 @@ mod haskell {
                 }]),
             },
             TestCase {
-                id: 0,
+                id: 1,
                 input_parameters: Box::new([Parameter {
                     value_type: ParameterType::Float,
                     value: String::from("3.3"),
@@ -792,7 +792,7 @@ mod haskell {
                 }]),
             },
             TestCase {
-                id: 0,
+                id: 1,
                 input_parameters: Box::new([Parameter {
                     value_type: ParameterType::Char,
                     value: String::from("b"),
@@ -851,7 +851,7 @@ mod haskell {
                 }]),
             },
             TestCase {
-                id: 0,
+                id: 1,
                 input_parameters: Box::new([Parameter {
                     value_type: ParameterType::String,
                     value: String::from("world"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -226,6 +226,25 @@ mod haskell {
 
         assert_eq!(actual.status(), expected_status_code);
     }
+
+    #[tokio::test]
+    async fn empty_request_body() {
+        let mozart = app();
+        let expected_status_code = StatusCode::BAD_REQUEST;
+        let request = Builder::new()
+            .method(Method::POST)
+            .header("Content-Type", "application/json")
+            .uri("/submit")
+            .body(Body::empty())
+            .expect("failed to build request");
+
+        let actual = mozart
+            .oneshot(request)
+            .await
+            .expect("failed to await oneshot");
+
+        assert_eq!(actual.status(), expected_status_code);
+    }
     #[tokio::test]
     async fn solution_with_all_data_types_as_input() {
         let mozart = app();

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,7 +168,7 @@ mod status {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "haskell"))]
 mod haskell {
     // example integration test cases
     // - all test cases pass (for all data types)

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,6 +208,24 @@ mod haskell {
 
         assert_eq!(actual.status(), expected_status_code);
     }
+
+    #[tokio::test]
+    async fn no_json_header() {
+        let mozart = app();
+        let expected_status_code = StatusCode::UNSUPPORTED_MEDIA_TYPE;
+        let request = Builder::new()
+            .method(Method::POST)
+            .uri("/submit")
+            .body(Body::empty())
+            .expect("failed to build request");
+
+        let actual = mozart
+            .oneshot(request)
+            .await
+            .expect("failed to await oneshot");
+
+        assert_eq!(actual.status(), expected_status_code);
+    }
     #[tokio::test]
     async fn solution_with_all_data_types_as_input() {
         let mozart = app();

--- a/src/main.rs
+++ b/src/main.rs
@@ -467,7 +467,7 @@ mod haskell {
     #[tokio::test]
     async fn compile_timeout() {
         let mozart = app();
-        let repeated = "  + x\n".repeat(20000);
+        let repeated = "  + x\n".repeat(100000);
         let solution = [
             "solution :: Int -> Int",
             "solution x =",

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,3 +167,16 @@ mod status {
         assert!(actual.body().is_end_stream());
     }
 }
+
+#[cfg(test)]
+mod haskell {
+    // example integration test cases
+    // - all test cases pass (for all data types)
+    // - all test cases wrong answer (for all data types)
+    // - runtime error in no last test case
+    // - solution with multiple different data types as input (possibly one with all different data types, like a string creation exercise or something)
+    // - solution with multiple different data types as output
+    // - compilation error
+    // - timeout error on execution (i think compilation is impossible to check unfortunately)
+    // - mix of pass and fail test cases + runtime error at some point
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,14 +171,8 @@ mod status {
 #[cfg(all(test, feature = "haskell"))]
 mod haskell {
     // example integration test cases
-    // - all test cases pass (for all data types)
     // - all test cases wrong answer (for all data types)
     // - runtime error in non last test case
-    // - solution with multiple different data types as input (possibly one with all different data types, like a string creation exercise or something) +
-    // - solution with multiple different data types as output +
-    // - compilation error +
-    // - timeout error on execution +
-    // - timeout error on compilation +
     // - mix of pass and fail test cases + runtime error at some point
 
     use crate::{
@@ -602,5 +596,300 @@ mod haskell {
         } else {
             panic!("response body was not of error variant");
         }
+    }
+
+    #[tokio::test]
+    async fn all_test_cases_pass_int() {
+        let mozart = app();
+        let solution = ["solution :: Int -> Int", "solution x = x + x"].join("\n");
+        let test_cases = Box::new([
+            TestCase {
+                id: 0,
+                input_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Int,
+                    value: String::from("10"),
+                }]),
+                output_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Int,
+                    value: String::from("20"),
+                }]),
+            },
+            TestCase {
+                id: 0,
+                input_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Int,
+                    value: String::from("5"),
+                }]),
+                output_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Int,
+                    value: String::from("10"),
+                }]),
+            },
+        ]);
+        let submission = Submission {
+            solution,
+            test_cases,
+        };
+        let body = serde_json::to_string(&submission).expect("failed to serialize submission");
+        let request = Builder::new()
+            .header("Content-Type", "application/json")
+            .method(Method::POST)
+            .uri("/submit")
+            .body(Body::from(body))
+            .expect("failed to build request");
+        let expected_status = StatusCode::OK;
+        let expected_body = SubmissionResult::Pass;
+
+        let actual = mozart
+            .oneshot(request)
+            .await
+            .expect("failed to execute oneshot request");
+
+        let actual_status = actual.status();
+        let body_bytes = to_bytes(actual.into_body(), usize::MAX)
+            .await
+            .expect("failed to convert body to bytes");
+
+        let actual_body: SubmissionResult =
+            serde_json::from_slice(&body_bytes).expect("failed to deserialize response body");
+
+        assert_eq!(actual_status, expected_status);
+        assert_eq!(actual_body, expected_body);
+    }
+
+    #[tokio::test]
+    async fn all_test_cases_pass_bool() {
+        let mozart = app();
+        let solution = ["solution :: Bool -> Bool", "solution b = not b"].join("\n");
+        let test_cases = Box::new([
+            TestCase {
+                id: 0,
+                input_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Bool,
+                    value: String::from("true"),
+                }]),
+                output_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Bool,
+                    value: String::from("false"),
+                }]),
+            },
+            TestCase {
+                id: 0,
+                input_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Bool,
+                    value: String::from("false"),
+                }]),
+                output_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Bool,
+                    value: String::from("true"),
+                }]),
+            },
+        ]);
+        let submission = Submission {
+            solution,
+            test_cases,
+        };
+        let body = serde_json::to_string(&submission).expect("failed to serialize submission");
+        let request = Builder::new()
+            .header("Content-Type", "application/json")
+            .method(Method::POST)
+            .uri("/submit")
+            .body(Body::from(body))
+            .expect("failed to build request");
+        let expected_status = StatusCode::OK;
+        let expected_body = SubmissionResult::Pass;
+
+        let actual = mozart
+            .oneshot(request)
+            .await
+            .expect("failed to execute oneshot request");
+
+        let actual_status = actual.status();
+        let body_bytes = to_bytes(actual.into_body(), usize::MAX)
+            .await
+            .expect("failed to convert body to bytes");
+
+        let actual_body: SubmissionResult =
+            serde_json::from_slice(&body_bytes).expect("failed to deserialize response body");
+
+        assert_eq!(actual_status, expected_status);
+        assert_eq!(actual_body, expected_body);
+    }
+
+    #[tokio::test]
+    async fn all_test_cases_pass_float() {
+        let mozart = app();
+        let solution = ["solution :: Float -> Float", "solution f = f + f"].join("\n");
+        let test_cases = Box::new([
+            TestCase {
+                id: 0,
+                input_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Float,
+                    value: String::from("2.5"),
+                }]),
+                output_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Float,
+                    value: String::from("5.0"),
+                }]),
+            },
+            TestCase {
+                id: 0,
+                input_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Float,
+                    value: String::from("3.3"),
+                }]),
+                output_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Float,
+                    value: String::from("6.6"),
+                }]),
+            },
+        ]);
+        let submission = Submission {
+            solution,
+            test_cases,
+        };
+        let body = serde_json::to_string(&submission).expect("failed to serialize submission");
+        let request = Builder::new()
+            .header("Content-Type", "application/json")
+            .method(Method::POST)
+            .uri("/submit")
+            .body(Body::from(body))
+            .expect("failed to build request");
+        let expected_status = StatusCode::OK;
+        let expected_body = SubmissionResult::Pass;
+
+        let actual = mozart
+            .oneshot(request)
+            .await
+            .expect("failed to execute oneshot request");
+
+        let actual_status = actual.status();
+        let body_bytes = to_bytes(actual.into_body(), usize::MAX)
+            .await
+            .expect("failed to convert body to bytes");
+
+        let actual_body: SubmissionResult =
+            serde_json::from_slice(&body_bytes).expect("failed to deserialize response body");
+
+        assert_eq!(actual_status, expected_status);
+        assert_eq!(actual_body, expected_body);
+    }
+
+    #[tokio::test]
+    async fn all_test_cases_pass_char() {
+        let mozart = app();
+        let solution = ["solution :: Char -> Char", "solution c = c"].join("\n");
+        let test_cases = Box::new([
+            TestCase {
+                id: 0,
+                input_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Char,
+                    value: String::from("a"),
+                }]),
+                output_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Char,
+                    value: String::from("a"),
+                }]),
+            },
+            TestCase {
+                id: 0,
+                input_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Char,
+                    value: String::from("b"),
+                }]),
+                output_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Char,
+                    value: String::from("b"),
+                }]),
+            },
+        ]);
+        let submission = Submission {
+            solution,
+            test_cases,
+        };
+        let body = serde_json::to_string(&submission).expect("failed to serialize submission");
+        let request = Builder::new()
+            .header("Content-Type", "application/json")
+            .method(Method::POST)
+            .uri("/submit")
+            .body(Body::from(body))
+            .expect("failed to build request");
+        let expected_status = StatusCode::OK;
+        let expected_body = SubmissionResult::Pass;
+
+        let actual = mozart
+            .oneshot(request)
+            .await
+            .expect("failed to execute oneshot request");
+
+        let actual_status = actual.status();
+        let body_bytes = to_bytes(actual.into_body(), usize::MAX)
+            .await
+            .expect("failed to convert body to bytes");
+
+        let actual_body: SubmissionResult =
+            serde_json::from_slice(&body_bytes).expect("failed to deserialize response body");
+
+        assert_eq!(actual_status, expected_status);
+        assert_eq!(actual_body, expected_body);
+    }
+
+    #[tokio::test]
+    async fn all_test_cases_pass_string() {
+        let mozart = app();
+        let solution = ["solution :: String -> String", "solution s = s ++ s"].join("\n");
+        let test_cases = Box::new([
+            TestCase {
+                id: 0,
+                input_parameters: Box::new([Parameter {
+                    value_type: ParameterType::String,
+                    value: String::from("hello"),
+                }]),
+                output_parameters: Box::new([Parameter {
+                    value_type: ParameterType::String,
+                    value: String::from("hellohello"),
+                }]),
+            },
+            TestCase {
+                id: 0,
+                input_parameters: Box::new([Parameter {
+                    value_type: ParameterType::String,
+                    value: String::from("world"),
+                }]),
+                output_parameters: Box::new([Parameter {
+                    value_type: ParameterType::String,
+                    value: String::from("worldworld"),
+                }]),
+            },
+        ]);
+        let submission = Submission {
+            solution,
+            test_cases,
+        };
+        let body = serde_json::to_string(&submission).expect("failed to serialize submission");
+        let request = Builder::new()
+            .header("Content-Type", "application/json")
+            .method(Method::POST)
+            .uri("/submit")
+            .body(Body::from(body))
+            .expect("failed to build request");
+        let expected_status = StatusCode::OK;
+        let expected_body = SubmissionResult::Pass;
+
+        let actual = mozart
+            .oneshot(request)
+            .await
+            .expect("failed to execute oneshot request");
+
+        let actual_status = actual.status();
+        let body_bytes = to_bytes(actual.into_body(), usize::MAX)
+            .await
+            .expect("failed to convert body to bytes");
+
+        let actual_body: SubmissionResult =
+            serde_json::from_slice(&body_bytes).expect("failed to deserialize response body");
+
+        assert_eq!(actual_status, expected_status);
+        assert_eq!(actual_body, expected_body);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,7 +177,7 @@ mod haskell {
     // - solution with multiple different data types as input (possibly one with all different data types, like a string creation exercise or something) +
     // - solution with multiple different data types as output +
     // - compilation error +
-    // - timeout error on execution
+    // - timeout error on execution +
     // - timeout error on compilation +
     // - mix of pass and fail test cases + runtime error at some point
 
@@ -535,6 +535,70 @@ mod haskell {
 
         if let SubmissionResult::Error(err) = actual_body {
             assert!(err.starts_with("compilation exceeded the timeout limit of"));
+        } else {
+            panic!("response body was not of error variant");
+        }
+    }
+
+    #[tokio::test]
+    async fn execution_timeout() {
+        let mozart = app();
+        let solution = ["solution :: Int -> Int", "solution x = solution x"].join("\n");
+        // the contents of the test cases are entirely irrelevant
+        let test_cases = Box::new([
+            TestCase {
+                id: 0,
+                input_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Int,
+                    value: String::from("10"),
+                }]),
+                output_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Int,
+                    value: String::from("10"),
+                }]),
+            },
+            TestCase {
+                id: 0,
+                input_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Int,
+                    value: String::from("-10"),
+                }]),
+                output_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Int,
+                    value: String::from("10"),
+                }]),
+            },
+        ]);
+        let submission = Submission {
+            solution,
+            test_cases,
+        };
+        let body = serde_json::to_string(&submission).expect("failed to serialize submission");
+        let request = Builder::new()
+            .header("Content-Type", "application/json")
+            .method(Method::POST)
+            .uri("/submit")
+            .body(Body::from(body))
+            .expect("failed to build request");
+        let expected_status = StatusCode::OK;
+
+        let actual = mozart
+            .oneshot(request)
+            .await
+            .expect("failed to execute oneshot request");
+
+        let actual_status = actual.status();
+        let body_bytes = to_bytes(actual.into_body(), usize::MAX)
+            .await
+            .expect("failed to convert body to bytes");
+
+        let actual_body: SubmissionResult =
+            serde_json::from_slice(&body_bytes).expect("failed to deserialize response body");
+
+        assert_eq!(actual_status, expected_status);
+
+        if let SubmissionResult::Error(err) = actual_body {
+            assert!(err.starts_with("execution exceeded the timeout limit of"));
         } else {
             panic!("response body was not of error variant");
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,7 +177,8 @@ mod haskell {
     // - solution with multiple different data types as input (possibly one with all different data types, like a string creation exercise or something) +
     // - solution with multiple different data types as output +
     // - compilation error +
-    // - timeout error on execution (i think compilation is impossible to check unfortunately)
+    // - timeout error on execution
+    // - timeout error on compilation +
     // - mix of pass and fail test cases + runtime error at some point
 
     use crate::{
@@ -463,6 +464,77 @@ mod haskell {
 
         if let SubmissionResult::Error(err) = actual_body {
             assert!(err.starts_with("an error occurred during compilation:"));
+        } else {
+            panic!("response body was not of error variant");
+        }
+    }
+
+    #[tokio::test]
+    async fn compile_timeout() {
+        let mozart = app();
+        let repeated = "  + x\n".repeat(10000);
+        let solution = [
+            "solution :: Int -> Int",
+            "solution x =",
+            "  x",
+            repeated.as_str(),
+        ]
+        .join("\n");
+        // the contents of the test cases are entirely irrelevant
+        let test_cases = Box::new([
+            TestCase {
+                id: 0,
+                input_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Int,
+                    value: String::from("10"),
+                }]),
+                output_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Int,
+                    value: String::from("10"),
+                }]),
+            },
+            TestCase {
+                id: 0,
+                input_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Int,
+                    value: String::from("-10"),
+                }]),
+                output_parameters: Box::new([Parameter {
+                    value_type: ParameterType::Int,
+                    value: String::from("10"),
+                }]),
+            },
+        ]);
+        let submission = Submission {
+            solution,
+            test_cases,
+        };
+        let body = serde_json::to_string(&submission).expect("failed to serialize submission");
+        let request = Builder::new()
+            .header("Content-Type", "application/json")
+            .method(Method::POST)
+            .uri("/submit")
+            .body(Body::from(body))
+            .expect("failed to build request");
+        let expected_status = StatusCode::OK;
+
+        let actual = mozart
+            .oneshot(request)
+            .await
+            .expect("failed to execute oneshot request");
+
+        let actual_status = actual.status();
+        let body_bytes = to_bytes(actual.into_body(), usize::MAX)
+            .await
+            .expect("failed to convert body to bytes");
+
+        let actual_body: SubmissionResult =
+            serde_json::from_slice(&body_bytes).expect("failed to deserialize response body");
+
+        assert_eq!(actual_status, expected_status);
+
+        if let SubmissionResult::Error(err) = actual_body {
+            assert!(err.starts_with("compilation exceeded the timeout limit of"));
         } else {
             panic!("response body was not of error variant");
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,68 +104,66 @@ async fn submit(Json(submission): Json<Submission>) -> SubmissionResult {
 }
 
 #[cfg(test)]
-mod endpoints {
-    mod status {
-        use crate::app;
-        use axum::{
-            body::{Body, HttpBody},
-            http::{request::Builder, Method, StatusCode},
-        };
-        use tower::ServiceExt;
+mod status {
+    use crate::app;
+    use axum::{
+        body::{Body, HttpBody},
+        http::{request::Builder, Method, StatusCode},
+    };
+    use tower::ServiceExt;
 
-        #[tokio::test]
-        async fn invalid_http_method() {
-            let mozart = app();
-            let expected_status_code = StatusCode::METHOD_NOT_ALLOWED;
-            let request = Builder::new()
-                .method(Method::POST)
-                .uri("/status")
-                .body(Body::empty())
-                .expect("failed to build request");
+    #[tokio::test]
+    async fn invalid_http_method() {
+        let mozart = app();
+        let expected_status_code = StatusCode::METHOD_NOT_ALLOWED;
+        let request = Builder::new()
+            .method(Method::POST)
+            .uri("/status")
+            .body(Body::empty())
+            .expect("failed to build request");
 
-            let actual = mozart
-                .oneshot(request)
-                .await
-                .expect("failed to await oneshot");
+        let actual = mozart
+            .oneshot(request)
+            .await
+            .expect("failed to await oneshot");
 
-            assert_eq!(actual.status(), expected_status_code);
-        }
+        assert_eq!(actual.status(), expected_status_code);
+    }
 
-        #[tokio::test]
-        async fn body_content_does_not_affect_request() {
-            let mozart = app();
-            let expected_status_code = StatusCode::OK;
-            let request = Builder::new()
-                .method(Method::GET)
-                .uri("/status")
-                .body(Body::from("Hello, world!"))
-                .expect("failed to build request");
+    #[tokio::test]
+    async fn body_content_does_not_affect_request() {
+        let mozart = app();
+        let expected_status_code = StatusCode::OK;
+        let request = Builder::new()
+            .method(Method::GET)
+            .uri("/status")
+            .body(Body::from("Hello, world!"))
+            .expect("failed to build request");
 
-            let actual = mozart
-                .oneshot(request)
-                .await
-                .expect("failed to await oneshot");
+        let actual = mozart
+            .oneshot(request)
+            .await
+            .expect("failed to await oneshot");
 
-            assert_eq!(actual.status(), expected_status_code);
-        }
+        assert_eq!(actual.status(), expected_status_code);
+    }
 
-        #[tokio::test]
-        async fn valid() {
-            let mozart = app();
-            let expected_status_code = StatusCode::OK;
-            let request = Builder::new()
-                .method(Method::GET)
-                .uri("/status")
-                .body(Body::empty())
-                .expect("failed to build request");
+    #[tokio::test]
+    async fn valid() {
+        let mozart = app();
+        let expected_status_code = StatusCode::OK;
+        let request = Builder::new()
+            .method(Method::GET)
+            .uri("/status")
+            .body(Body::empty())
+            .expect("failed to build request");
 
-            let actual = mozart
-                .oneshot(request)
-                .await
-                .expect("failed to await oneshot");
+        let actual = mozart
+            .oneshot(request)
+            .await
+            .expect("failed to await oneshot");
 
-            assert_eq!(actual.status(), expected_status_code);
-            assert!(actual.body().is_end_stream());
-        }
+        assert_eq!(actual.status(), expected_status_code);
+        assert!(actual.body().is_end_stream());
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -5,7 +5,7 @@
 use serde::{Deserialize, Serialize};
 
 /// A submission provided by the backend.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Submission {
     /// The user submitted solution.
@@ -16,7 +16,7 @@ pub struct Submission {
 }
 
 /// A test case for a given exercise.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct TestCase {
     /// The test case id, this is not relevant for mozart, but knowing which test cases failed,
@@ -70,7 +70,7 @@ pub enum ParameterType {
 }
 
 /// A test case result, indicating how a solution handled a given test case.
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct TestCaseResult {
     /// The id of the test case.
@@ -82,7 +82,7 @@ pub struct TestCaseResult {
 }
 
 /// The different outcomes of a test case.
-#[derive(Serialize, PartialEq, Debug)]
+#[derive(Deserialize, Serialize, PartialEq, Debug)]
 #[serde(rename_all = "camelCase", tag = "testResult")]
 pub enum TestResult {
     /// The test case passed.
@@ -98,7 +98,7 @@ pub enum TestResult {
 }
 
 /// The reason why a given test case failed.
-#[derive(Serialize, PartialEq, Debug)]
+#[derive(Deserialize, Serialize, PartialEq, Debug)]
 #[serde(rename_all = "camelCase", tag = "cause", content = "details")]
 pub enum TestCaseFailureReason {
     /// The answer to the test case was incorrect.

--- a/src/model.rs
+++ b/src/model.rs
@@ -70,7 +70,7 @@ pub enum ParameterType {
 }
 
 /// A test case result, indicating how a solution handled a given test case.
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct TestCaseResult {
     /// The id of the test case.

--- a/src/response.rs
+++ b/src/response.rs
@@ -6,12 +6,12 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// A submission result indicates the result of checking a given submission.
 ///
 /// This is an outward facing object, as it is serialized to JSON in the HTTP response for a given request.
-#[derive(Serialize)]
+#[derive(Deserialize, Serialize)]
 #[serde(tag = "result", content = "reason")]
 pub enum SubmissionResult {
     /// A submission successfully passed all test cases.

--- a/src/response.rs
+++ b/src/response.rs
@@ -6,16 +6,14 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
-use serde::{Deserialize, Serialize};
+use serde::{ser::SerializeStruct, Serialize};
 
 /// A submission result indicates the result of checking a given submission.
 ///
 /// This is an outward facing object, as it is serialized to JSON in the HTTP response for a given request.
-#[derive(Deserialize, Serialize, Debug, PartialEq)]
-#[serde(tag = "result", content = "reason")]
+#[derive(Debug, PartialEq)]
 pub enum SubmissionResult {
     /// A submission successfully passed all test cases.
-    #[serde(rename = "pass")]
     Pass,
 
     /// A submission did not pass all test cases.
@@ -23,7 +21,6 @@ pub enum SubmissionResult {
     /// The `Box<[TestCaseResult]>` should contain a slice of test case results,
     /// both for passed and failed test cases. This way the frontend can
     /// correctly identify which test cases failed, and why they failed.
-    #[serde(rename = "failure")]
     Failure(Box<[TestCaseResult]>),
 
     /// An error occured at some point during the check of the submission.
@@ -32,12 +29,37 @@ pub enum SubmissionResult {
     /// is responsible for, such at compilation errors, timeouts and the like.
     ///
     /// The `String` is the underlying [`SubmissionError`] in string format.
-    #[serde(rename = "error")]
     Error(String),
 
     /// An internal error represents something that the user is not at fault for,
     /// for example, not being able to spawn a compilation process, or creating a file.
     InternalError,
+}
+
+impl Serialize for SubmissionResult {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut json = serializer.serialize_struct("SubmissionResult", 2)?;
+        match self {
+            SubmissionResult::Pass => {
+                json.serialize_field("result", "pass")?;
+            }
+            SubmissionResult::Failure(test_cases) => {
+                json.serialize_field("result", "failure")?;
+                json.serialize_field("testCaseResults", test_cases)?;
+            }
+            SubmissionResult::Error(error) => {
+                json.serialize_field("result", "error")?;
+                json.serialize_field("message", error)?;
+            }
+            SubmissionResult::InternalError => {
+                unreachable!("cannot happen because internal server error is not parsed to json")
+            }
+        }
+        json.end()
+    }
 }
 
 impl IntoResponse for SubmissionResult {
@@ -57,5 +79,66 @@ impl From<SubmissionError> for SubmissionResult {
             SubmissionError::Failure(tcr) => SubmissionResult::Failure(tcr),
             other => SubmissionResult::Error(other.to_string()),
         }
+    }
+}
+
+#[cfg(test)]
+use serde::de;
+
+#[cfg(test)]
+impl<'de> de::Deserialize<'de> for SubmissionResult {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct SubmissionResultVisitor;
+
+        impl<'de> de::Visitor<'de> for SubmissionResultVisitor {
+            type Value = SubmissionResult;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a valid SubmissionResult")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+            where
+                V: de::MapAccess<'de>,
+            {
+                let mut result: Option<String> = None;
+                let mut test_case_results: Option<Box<[TestCaseResult]>> = None;
+                let mut message: Option<String> = None;
+
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "result" => {
+                            result = Some(map.next_value()?);
+                        }
+                        "testCaseResults" => {
+                            test_case_results = Some(map.next_value()?);
+                        }
+                        "message" => {
+                            message = Some(map.next_value()?);
+                        }
+                        _ => {
+                            let _: serde::de::IgnoredAny = map.next_value()?;
+                        }
+                    }
+                }
+
+                match result.as_deref() {
+                    Some("pass") => Ok(SubmissionResult::Pass),
+                    Some("failure") => Ok(SubmissionResult::Failure(
+                        test_case_results
+                            .ok_or_else(|| de::Error::missing_field("testCaseResults"))?,
+                    )),
+                    Some("error") => Ok(SubmissionResult::Error(
+                        message.ok_or_else(|| de::Error::missing_field("message"))?,
+                    )),
+                    _ => Err(de::Error::custom("unknown variant for SubmissionResult")),
+                }
+            }
+        }
+
+        deserializer.deserialize_map(SubmissionResultVisitor)
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 /// A submission result indicates the result of checking a given submission.
 ///
 /// This is an outward facing object, as it is serialized to JSON in the HTTP response for a given request.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
 #[serde(tag = "result", content = "reason")]
 pub enum SubmissionResult {
     /// A submission successfully passed all test cases.

--- a/src/runner/haskell.rs
+++ b/src/runner/haskell.rs
@@ -10,8 +10,13 @@ use std::{path::PathBuf, process::Stdio, time::Duration};
 use tokio::process::Command;
 use tracing::{debug, error, info};
 
+#[cfg(not(feature = "ci"))]
 /// The timeout duration for the compilation and execution process.
 const TIMEOUT: Duration = Duration::from_secs(5);
+
+#[cfg(feature = "ci")]
+/// The timeout duration used during pipeline workflows.
+const TIMEOUT: Duration = Duration::from_secs(30);
 
 /// The base test 'runner' code for Haskell.
 ///

--- a/src/runner/haskell.rs
+++ b/src/runner/haskell.rs
@@ -71,7 +71,7 @@ impl LanguageHandler for Haskell {
                 .iter()
                 .map(|op| self.format_parameter(op))
                 .collect::<Vec<String>>()
-                .join(" ");
+                .join(",");
 
             let generated_test_case = format!(
                 "  testChecker (solution {formatted_input_parameters}) ({formatted_output_parameters})"

--- a/src/runner/haskell.rs
+++ b/src/runner/haskell.rs
@@ -11,7 +11,7 @@ use tokio::process::Command;
 use tracing::{debug, error, info};
 
 /// The timeout duration for the compilation and execution process.
-const TIMEOUT: Duration = Duration::from_secs(5);
+const TIMEOUT: Duration = Duration::from_secs(10);
 
 /// The base test 'runner' code for Haskell.
 ///

--- a/src/runner/haskell.rs
+++ b/src/runner/haskell.rs
@@ -11,7 +11,7 @@ use tokio::process::Command;
 use tracing::{debug, error, info};
 
 /// The timeout duration for the compilation and execution process.
-const TIMEOUT: Duration = Duration::from_secs(10);
+const TIMEOUT: Duration = Duration::from_secs(5);
 
 /// The base test 'runner' code for Haskell.
 ///

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -246,6 +246,15 @@ mod parse_output_file {
         },
     };
 
+    /// A test util function to make a test case with the supplied `id` and empty parameters.
+    fn empty_test_case(id: u64) -> TestCase {
+        TestCase {
+            id,
+            input_parameters: Box::new([]),
+            output_parameters: Box::new([]),
+        }
+    }
+
     #[test]
     fn empty_file() {
         let test_output = "";
@@ -270,23 +279,7 @@ mod parse_output_file {
     fn empty_line() {
         let test_output = ["p", "", "p"].join("\n");
         // the parameters are not necessary for this test, only the test case id
-        let test_cases = [
-            TestCase {
-                id: 0,
-                input_parameters: Box::new([]),
-                output_parameters: Box::new([]),
-            },
-            TestCase {
-                id: 1,
-                input_parameters: Box::new([]),
-                output_parameters: Box::new([]),
-            },
-            TestCase {
-                id: 2,
-                input_parameters: Box::new([]),
-                output_parameters: Box::new([]),
-            },
-        ];
+        let test_cases = [empty_test_case(0), empty_test_case(1), empty_test_case(2)];
         let expected = Err(SubmissionError::Internal);
 
         let actual = TestRunner::parse_test_output(&test_output, &test_cases);
@@ -298,11 +291,7 @@ mod parse_output_file {
     fn failure_outcome_without_actual_and_expected() {
         let test_output = ["f"].join("\n");
         // the parameters are not necessary for this test, only the test case id
-        let test_cases = [TestCase {
-            id: 0,
-            input_parameters: Box::new([]),
-            output_parameters: Box::new([]),
-        }];
+        let test_cases = [empty_test_case(0)];
         let expected = Err(SubmissionError::Internal);
 
         let actual = TestRunner::parse_test_output(&test_output, &test_cases);
@@ -314,11 +303,7 @@ mod parse_output_file {
     fn failure_outcome_with_actual_but_without_expected() {
         let test_output = ["f,5"].join("\n");
         // the parameters are not necessary for this test, only the test case id
-        let test_cases = [TestCase {
-            id: 0,
-            input_parameters: Box::new([]),
-            output_parameters: Box::new([]),
-        }];
+        let test_cases = [empty_test_case(0)];
         let expected = Err(SubmissionError::Internal);
 
         let actual = TestRunner::parse_test_output(&test_output, &test_cases);
@@ -330,18 +315,7 @@ mod parse_output_file {
     fn unknown_test_output() {
         let test_output = ["p", "r"].join("\n");
         // the parameters are not necessary for this test, only the test case id
-        let test_cases = [
-            TestCase {
-                id: 0,
-                input_parameters: Box::new([]),
-                output_parameters: Box::new([]),
-            },
-            TestCase {
-                id: 1,
-                input_parameters: Box::new([]),
-                output_parameters: Box::new([]),
-            },
-        ];
+        let test_cases = [empty_test_case(0), empty_test_case(1)];
         let expected = Err(SubmissionError::Internal);
 
         let actual = TestRunner::parse_test_output(&test_output, &test_cases);
@@ -357,18 +331,7 @@ mod parse_output_file {
     fn runtime_error_in_last_test_case() -> Result<(), SubmissionError> {
         let test_output = ["p"].join("\n");
         // the parameters are not necessary for this test, only the test case id
-        let test_cases = [
-            TestCase {
-                id: 0,
-                input_parameters: Box::new([]),
-                output_parameters: Box::new([]),
-            },
-            TestCase {
-                id: 1,
-                input_parameters: Box::new([]),
-                output_parameters: Box::new([]),
-            },
-        ];
+        let test_cases = [empty_test_case(0), empty_test_case(1)];
         let expected = Box::new([
             TestCaseResult {
                 id: 0,
@@ -419,31 +382,11 @@ mod parse_output_file {
         let test_output = ["p", "p", "p", "p", "p"].join("\n");
         // the parameters are not necessary for this test, only the test case id
         let test_cases = [
-            TestCase {
-                id: 0,
-                input_parameters: Box::new([]),
-                output_parameters: Box::new([]),
-            },
-            TestCase {
-                id: 1,
-                input_parameters: Box::new([]),
-                output_parameters: Box::new([]),
-            },
-            TestCase {
-                id: 2,
-                input_parameters: Box::new([]),
-                output_parameters: Box::new([]),
-            },
-            TestCase {
-                id: 3,
-                input_parameters: Box::new([]),
-                output_parameters: Box::new([]),
-            },
-            TestCase {
-                id: 4,
-                input_parameters: Box::new([]),
-                output_parameters: Box::new([]),
-            },
+            empty_test_case(0),
+            empty_test_case(1),
+            empty_test_case(2),
+            empty_test_case(3),
+            empty_test_case(4),
         ];
         let expected = Box::new([
             TestCaseResult {

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -222,7 +222,7 @@ impl TestRunner {
         }
 
         // handling the remaining test cases which are considered unknown (were not run)
-        for test_case in test_cases.iter().skip(test_cases.len()) {
+        for test_case in test_cases.iter().skip(test_case_results.len()) {
             debug!("test case '{}' is unknown", test_case.id);
             let result = TestCaseResult {
                 id: test_case.id,

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -156,10 +156,10 @@ impl TestRunner {
     ) -> Result<Box<[TestCaseResult]>, SubmissionError> {
         info!("parsing output file");
 
-        if test_output.trim().is_empty() {
-            error!("test output file is empty");
-            return Err(SubmissionError::Internal);
-        }
+        // if test_output.trim().is_empty() {
+        //     error!("test output file is empty");
+        //     return Err(SubmissionError::Internal);
+        // }
 
         let mut test_case_results = Vec::new();
         for (index, line) in test_output.lines().enumerate() {
@@ -256,26 +256,6 @@ mod parse_output_file {
     }
 
     #[test]
-    fn empty_file() {
-        let test_output = "";
-        let expected = Err(SubmissionError::Internal);
-
-        let actual = TestRunner::parse_test_output(test_output, &[]);
-
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn only_newline() {
-        let test_output = "\n";
-        let expected = Err(SubmissionError::Internal);
-
-        let actual = TestRunner::parse_test_output(test_output, &[]);
-
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
     fn empty_line() {
         let test_output = ["p", "", "p"].join("\n");
         // the parameters are not necessary for this test, only the test case id
@@ -323,10 +303,6 @@ mod parse_output_file {
         assert_eq!(actual, expected);
     }
 
-    // unsure how this should be handled as it would just be an empty output file
-    // #[test]
-    // fn runtime_error_in_first_test_case() {}
-
     #[test]
     fn runtime_error_in_last_test_case() -> Result<(), SubmissionError> {
         let test_output = ["p"].join("\n");
@@ -350,32 +326,45 @@ mod parse_output_file {
         Ok(())
     }
 
-    // what do we want to do in this scenario?
-    // do we just ignore the remaining test case outputs and only consider the first
-    // *n* outputs with n being the amount of test cases? or do we just throw an error
-    // because we cant be sure that they answered the solution correctly because of the
-    // difference in length between output and test cases
-    //
-    // #[test]
-    // fn less_test_cases_than_output_lines() -> Result<(), SubmissionError> {
-    //     let test_output = ["p", "p"].join("\n");
-    //     // the parameters are not necessary for this test, only the test case id
-    //     let test_cases = [TestCase {
-    //         id: 0,
-    //         input_parameters: Box::new([]),
-    //         output_parameters: Box::new([]),
-    //     }];
-    //     let expected = Box::new([TestCaseResult {
-    //         id: 0,
-    //         test_result: TestResult::Pass,
-    //     }]);
+    #[test]
+    fn runtime_error_in_first_test_case() -> Result<(), SubmissionError> {
+        let test_output = "";
+        let test_cases = [
+            empty_test_case(0),
+            empty_test_case(1),
+            empty_test_case(2),
+            empty_test_case(3),
+            empty_test_case(4),
+        ];
+        let expected = Box::new([
+            TestCaseResult {
+                id: 0,
+                test_result: TestResult::Failure(TestCaseFailureReason::RuntimeError),
+            },
+            TestCaseResult {
+                id: 1,
+                test_result: TestResult::Unknown,
+            },
+            TestCaseResult {
+                id: 2,
+                test_result: TestResult::Unknown,
+            },
+            TestCaseResult {
+                id: 3,
+                test_result: TestResult::Unknown,
+            },
+            TestCaseResult {
+                id: 4,
+                test_result: TestResult::Unknown,
+            },
+        ]);
 
-    //     let actual = TestRunner::parse_test_output(&test_output, &test_cases)?;
+        let actual = TestRunner::parse_test_output(test_output, &test_cases)?;
 
-    //     assert_eq!(*actual, *expected);
+        assert_eq!(*actual, *expected);
 
-    //     Ok(())
-    // }
+        Ok(())
+    }
 
     #[test]
     fn all_test_cases_passed() -> Result<(), SubmissionError> {

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -155,6 +155,12 @@ impl TestRunner {
         test_cases: &[TestCase],
     ) -> Result<Box<[TestCaseResult]>, SubmissionError> {
         info!("parsing output file");
+
+        if test_output.trim().is_empty() {
+            error!("test output file is empty");
+            return Err(SubmissionError::Internal);
+        }
+
         let mut test_case_results = Vec::new();
         for (index, line) in test_output.lines().enumerate() {
             let test_case = &test_cases[index];


### PR DESCRIPTION
## Description
This PR adds integration (and a few unit) test cases.

It also updates the readme to include a bit more information.

### Resolved Issue
Fixes #26
Fixes #12 

## Changes
- refactor parsing output file to its own function
- add unit tests for parsing output file (there are some questions here regarding behaviour)
- a few refactors and clean ups
- fix error in generating return output for test cases
- add integration test cases (endpoint tests)
- update CI job to include GHC for the test suite

## Additional Information
There are some questions regarding behaviour when parsing output file, this should ideally be discussed.

## Checklist

- [x] I have added test cases for my additions
- [x] New and old tests passed
- [x] Documentation is updated
