### PR TITLE
refactor types to new agreed standard

### DIFF
--- a/.bruno/Haskell/Compilation Error.bru
+++ b/.bruno/Haskell/Compilation Error.bru
@@ -1,0 +1,50 @@
+meta {
+  name: Compilation Error
+  type: http
+  seq: 2
+}
+
+post {
+  url: http://localhost:8080/submit
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "solution": "solution x =\n  if x < 0\n    then x\n",
+    "testCases": [
+      {
+        "id": 0,
+        "inputParameters": [
+          {
+            "valueType": "int",
+            "value": "-5"
+          }
+        ],
+        "outputParameters": [
+          {
+            "valueType": "int",
+            "value": "5"
+          }
+        ]
+      },
+      {
+        "id": 1,
+        "inputParameters": [
+          {
+            "valueType": "int",
+            "value": "5"
+          }
+        ],
+        "outputParameters": [
+          {
+            "valueType": "int",
+            "value": "5"
+          }
+        ]
+      }
+    ]
+  }
+  
+}

--- a/.bruno/Haskell/Execution Timeout.bru
+++ b/.bruno/Haskell/Execution Timeout.bru
@@ -1,0 +1,49 @@
+meta {
+  name: Execution Timeout
+  type: http
+  seq: 1
+}
+
+post {
+  url: http://localhost:8080/submit
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "solution": "solution x = solution x",
+    "testCases": [
+      {
+        "id": 0,
+        "inputParameters": [
+          {
+            "valueType": "int",
+            "value": "-5"
+          }
+        ],
+        "outputParameters": [
+          {
+            "valueType": "int",
+            "value": "5"
+          }
+        ]
+      },
+      {
+        "id": 1,
+        "inputParameters": [
+          {
+            "valueType": "int",
+            "value": "5"
+          }
+        ],
+        "outputParameters": [
+          {
+            "valueType": "int",
+            "value": "5"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.bruno/Haskell/Failure/Bool.bru
+++ b/.bruno/Haskell/Failure/Bool.bru
@@ -1,5 +1,5 @@
 meta {
-  name: pass
+  name: Bool
   type: http
   seq: 2
 }
@@ -12,20 +12,20 @@ post {
 
 body:json {
   {
-    "solution": "solution x =\n  if x < 0\n    then x * (-1)\n    else x",
+    "solution": "solution :: Bool -> Bool\nsolution b = not b && True",
     "testCases": [
       {
         "id": 0,
         "inputParameters": [
           {
-            "valueType": "int",
-            "value": "-5"
+            "valueType": "bool",
+            "value": "false"
           }
         ],
         "outputParameters": [
           {
-            "valueType": "int",
-            "value": "5"
+            "valueType": "bool",
+            "value": "false"
           }
         ]
       },
@@ -33,14 +33,14 @@ body:json {
         "id": 1,
         "inputParameters": [
           {
-            "valueType": "int",
-            "value": "5"
+            "valueType": "bool",
+            "value": "true"
           }
         ],
         "outputParameters": [
           {
-            "valueType": "int",
-            "value": "5"
+            "valueType": "bool",
+            "value": "true"
           }
         ]
       }

--- a/.bruno/Haskell/Failure/Character.bru
+++ b/.bruno/Haskell/Failure/Character.bru
@@ -1,7 +1,7 @@
 meta {
-  name: failure, wrong answer
+  name: Character
   type: http
-  seq: 3
+  seq: 4
 }
 
 post {
@@ -12,20 +12,20 @@ post {
 
 body:json {
   {
-    "solution": "solution x =\n  if x < 0\n    then x\n    else x",
+    "solution": "solution :: Char -> Bool\nsolution c = c == 'b'",
     "testCases": [
       {
         "id": 0,
         "inputParameters": [
           {
-            "valueType": "int",
-            "value": "-5"
+            "valueType": "char",
+            "value": "a"
           }
         ],
         "outputParameters": [
           {
-            "valueType": "int",
-            "value": "5"
+            "valueType": "bool",
+            "value": "true"
           }
         ]
       },
@@ -33,14 +33,14 @@ body:json {
         "id": 1,
         "inputParameters": [
           {
-            "valueType": "int",
-            "value": "5"
+            "valueType": "char",
+            "value": "b"
           }
         ],
         "outputParameters": [
           {
-            "valueType": "int",
-            "value": "5"
+            "valueType": "bool",
+            "value": "false"
           }
         ]
       }

--- a/.bruno/Haskell/Failure/Floating Point.bru
+++ b/.bruno/Haskell/Failure/Floating Point.bru
@@ -1,0 +1,50 @@
+meta {
+  name: Floating Point
+  type: http
+  seq: 3
+}
+
+post {
+  url: http://localhost:8080/submit
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "solution": "solution :: Double -> Double\nsolution d = d * 3",
+    "testCases": [
+      {
+        "id": 0,
+        "inputParameters": [
+          {
+            "valueType": "float",
+            "value": "5.5"
+          }
+        ],
+        "outputParameters": [
+          {
+            "valueType": "float",
+            "value": "11.0"
+          }
+        ]
+      },
+      {
+        "id": 1,
+        "inputParameters": [
+          {
+            "valueType": "float",
+            "value": "2.3"
+          }
+        ],
+        "outputParameters": [
+          {
+            "valueType": "float",
+            "value": "4.6"
+          }
+        ]
+      }
+    ]
+  }
+  
+}

--- a/.bruno/Haskell/Failure/Integer.bru
+++ b/.bruno/Haskell/Failure/Integer.bru
@@ -1,5 +1,5 @@
 meta {
-  name: execution timeout
+  name: Integer
   type: http
   seq: 1
 }
@@ -12,7 +12,7 @@ post {
 
 body:json {
   {
-    "solution": "solution x = solution x",
+    "solution": "solution :: Int -> Int\nsolution x =\n  if x < 0\n    then x\n    else x",
     "testCases": [
       {
         "id": 0,
@@ -46,4 +46,5 @@ body:json {
       }
     ]
   }
+  
 }

--- a/.bruno/Haskell/Failure/String.bru
+++ b/.bruno/Haskell/Failure/String.bru
@@ -1,0 +1,50 @@
+meta {
+  name: String
+  type: http
+  seq: 5
+}
+
+post {
+  url: http://localhost:8080/submit
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "solution": "solution :: String -> Int\nsolution s = (length s) + 1",
+    "testCases": [
+      {
+        "id": 0,
+        "inputParameters": [
+          {
+            "valueType": "string",
+            "value": "hello"
+          }
+        ],
+        "outputParameters": [
+          {
+            "valueType": "int",
+            "value": "5"
+          }
+        ]
+      },
+      {
+        "id": 1,
+        "inputParameters": [
+          {
+            "valueType": "string",
+            "value": "mozart"
+          }
+        ],
+        "outputParameters": [
+          {
+            "valueType": "int",
+            "value": "6"
+          }
+        ]
+      }
+    ]
+  }
+  
+}

--- a/.bruno/Haskell/Pass/Bool.bru
+++ b/.bruno/Haskell/Pass/Bool.bru
@@ -1,0 +1,50 @@
+meta {
+  name: Bool
+  type: http
+  seq: 2
+}
+
+post {
+  url: http://localhost:8080/submit
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "solution": "solution :: Bool -> Bool\nsolution b = b && True",
+    "testCases": [
+      {
+        "id": 0,
+        "inputParameters": [
+          {
+            "valueType": "bool",
+            "value": "false"
+          }
+        ],
+        "outputParameters": [
+          {
+            "valueType": "bool",
+            "value": "false"
+          }
+        ]
+      },
+      {
+        "id": 1,
+        "inputParameters": [
+          {
+            "valueType": "bool",
+            "value": "true"
+          }
+        ],
+        "outputParameters": [
+          {
+            "valueType": "bool",
+            "value": "true"
+          }
+        ]
+      }
+    ]
+  }
+  
+}

--- a/.bruno/Haskell/Pass/Character.bru
+++ b/.bruno/Haskell/Pass/Character.bru
@@ -1,0 +1,50 @@
+meta {
+  name: Character
+  type: http
+  seq: 4
+}
+
+post {
+  url: http://localhost:8080/submit
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "solution": "solution :: Char -> Bool\nsolution c = c == 'a'",
+    "testCases": [
+      {
+        "id": 0,
+        "inputParameters": [
+          {
+            "valueType": "char",
+            "value": "a"
+          }
+        ],
+        "outputParameters": [
+          {
+            "valueType": "bool",
+            "value": "true"
+          }
+        ]
+      },
+      {
+        "id": 1,
+        "inputParameters": [
+          {
+            "valueType": "char",
+            "value": "b"
+          }
+        ],
+        "outputParameters": [
+          {
+            "valueType": "bool",
+            "value": "false"
+          }
+        ]
+      }
+    ]
+  }
+  
+}

--- a/.bruno/Haskell/Pass/Floating Point.bru
+++ b/.bruno/Haskell/Pass/Floating Point.bru
@@ -1,0 +1,50 @@
+meta {
+  name: Floating Point
+  type: http
+  seq: 3
+}
+
+post {
+  url: http://localhost:8080/submit
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "solution": "solution :: Double -> Double\nsolution d = d * 2",
+    "testCases": [
+      {
+        "id": 0,
+        "inputParameters": [
+          {
+            "valueType": "float",
+            "value": "5.5"
+          }
+        ],
+        "outputParameters": [
+          {
+            "valueType": "float",
+            "value": "11.0"
+          }
+        ]
+      },
+      {
+        "id": 1,
+        "inputParameters": [
+          {
+            "valueType": "float",
+            "value": "2.3"
+          }
+        ],
+        "outputParameters": [
+          {
+            "valueType": "float",
+            "value": "4.6"
+          }
+        ]
+      }
+    ]
+  }
+  
+}

--- a/.bruno/Haskell/Pass/Integer.bru
+++ b/.bruno/Haskell/Pass/Integer.bru
@@ -1,7 +1,7 @@
 meta {
-  name: compilation error
+  name: Integer
   type: http
-  seq: 4
+  seq: 1
 }
 
 post {
@@ -12,7 +12,7 @@ post {
 
 body:json {
   {
-    "solution": "solution x =\n  if x < 0\n    then x\n",
+    "solution": "solution :: Int -> Int\nsolution x =\n  if x < 0\n    then x * (-1)\n    else x",
     "testCases": [
       {
         "id": 0,

--- a/.bruno/Haskell/Pass/String.bru
+++ b/.bruno/Haskell/Pass/String.bru
@@ -1,5 +1,5 @@
 meta {
-  name: pass, bool
+  name: String
   type: http
   seq: 5
 }
@@ -12,20 +12,20 @@ post {
 
 body:json {
   {
-    "solution": "solution b = b && True",
+    "solution": "solution :: String -> Int\nsolution s = length s",
     "testCases": [
       {
         "id": 0,
         "inputParameters": [
           {
-            "valueType": "bool",
-            "value": "false"
+            "valueType": "string",
+            "value": "hello"
           }
         ],
         "outputParameters": [
           {
-            "valueType": "bool",
-            "value": "false"
+            "valueType": "int",
+            "value": "5"
           }
         ]
       },
@@ -33,14 +33,14 @@ body:json {
         "id": 1,
         "inputParameters": [
           {
-            "valueType": "bool",
-            "value": "true"
+            "valueType": "string",
+            "value": "mozart"
           }
         ],
         "outputParameters": [
           {
-            "valueType": "bool",
-            "value": "true"
+            "valueType": "int",
+            "value": "6"
           }
         ]
       }

--- a/.bruno/bruno.json
+++ b/.bruno/bruno.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "name": ".bruno",
+  "name": "Mozart",
   "type": "collection",
   "ignore": [
     "node_modules",

--- a/src/main.rs
+++ b/src/main.rs
@@ -266,7 +266,7 @@ mod haskell {
     async fn solution_with_all_data_types_as_input() {
         let mozart = app();
         let solution = [
-            "solution :: Int -> Float -> Bool -> Char -> String -> String",
+            "solution :: Int -> Double -> Bool -> Char -> String -> String",
             "solution int float bool char string = show int ++ show float ++ show bool ++ [char] ++ string"
         ].join("\n");
         let test_cases = Box::new([TestCase {
@@ -333,7 +333,7 @@ mod haskell {
     async fn solution_with_all_data_types_as_output_and_no_input() {
         let mozart = app();
         let solution = [
-            "solution :: (Int, Float, Bool, Char, String)",
+            "solution :: (Int, Double, Bool, Char, String)",
             r#"solution = (7, 8.6, True, 'a', "hhh")"#,
         ]
         .join("\n");
@@ -720,7 +720,7 @@ mod haskell {
     #[tokio::test]
     async fn all_test_cases_pass_float() {
         let mozart = app();
-        let solution = ["solution :: Float -> Float", "solution f = f + f"].join("\n");
+        let solution = ["solution :: Double -> Double", "solution f = f + f"].join("\n");
         let test_cases = Box::new([
             TestCase {
                 id: 0,
@@ -1061,7 +1061,7 @@ mod haskell {
     #[tokio::test]
     async fn all_test_cases_fail_float() {
         let mozart = app();
-        let solution = ["solution :: Float -> Float", "solution f = f"].join("\n");
+        let solution = ["solution :: Double -> Double", "solution f = f"].join("\n");
         let test_cases = Box::new([
             TestCase {
                 id: 0,

--- a/src/model.rs
+++ b/src/model.rs
@@ -56,10 +56,10 @@ pub enum ParameterType {
     /// A boolean value.
     Bool,
 
-    /// A signed integer.
+    /// A signed 64-bit integer.
     Int,
 
-    /// A floating point value.
+    /// A double precision floating point value (64-bit precision).
     Float,
 
     /// A character, or a single character string (depending on the language).

--- a/src/runner/haskell.rs
+++ b/src/runner/haskell.rs
@@ -223,7 +223,7 @@ mod format_parameter {
             value_type: ParameterType::Bool,
             value: String::from("false"),
         };
-        let expected = String::from("False");
+        let expected = String::from("(False :: Bool)");
 
         let actual = haskell.format_parameter(&input);
 
@@ -237,7 +237,7 @@ mod format_parameter {
             value_type: ParameterType::Bool,
             value: String::from("true"),
         };
-        let expected = String::from("True");
+        let expected = String::from("(True :: Bool)");
 
         let actual = haskell.format_parameter(&input);
 
@@ -251,7 +251,7 @@ mod format_parameter {
             value_type: ParameterType::Int,
             value: String::from("100"),
         };
-        let expected = String::from("(100)");
+        let expected = String::from("(100 :: Int)");
 
         let actual = haskell.format_parameter(&input);
 
@@ -265,7 +265,7 @@ mod format_parameter {
             value_type: ParameterType::Int,
             value: String::from("-100"),
         };
-        let expected = String::from("(-100)");
+        let expected = String::from("(-100 :: Int)");
 
         let actual = haskell.format_parameter(&input);
 
@@ -279,7 +279,7 @@ mod format_parameter {
             value_type: ParameterType::Float,
             value: String::from("10.0"),
         };
-        let expected = String::from("(10.0)");
+        let expected = String::from("(10.0 :: Double)");
 
         let actual = haskell.format_parameter(&input);
 
@@ -293,7 +293,7 @@ mod format_parameter {
             value_type: ParameterType::Float,
             value: String::from("-10.0"),
         };
-        let expected = String::from("(-10.0)");
+        let expected = String::from("(-10.0 :: Double)");
 
         let actual = haskell.format_parameter(&input);
 
@@ -307,7 +307,7 @@ mod format_parameter {
             value_type: ParameterType::Char,
             value: String::from("a"),
         };
-        let expected = String::from("'a'");
+        let expected = String::from("('a' :: Char)");
 
         let actual = haskell.format_parameter(&input);
 
@@ -321,7 +321,7 @@ mod format_parameter {
             value_type: ParameterType::String,
             value: String::from("hello"),
         };
-        let expected = String::from(r#""hello""#);
+        let expected = String::from(r#"("hello" :: String)"#);
 
         let actual = haskell.format_parameter(&input);
 

--- a/src/runner/haskell.rs
+++ b/src/runner/haskell.rs
@@ -89,14 +89,20 @@ impl LanguageHandler for Haskell {
 
     fn format_parameter(&self, parameter: &Parameter) -> String {
         match parameter.value_type {
-            ParameterType::Int | ParameterType::Float => format!("({})", parameter.value),
-            ParameterType::Char => format!("'{}'", parameter.value),
-            ParameterType::String => format!(r#""{}""#, parameter.value),
+            ParameterType::Int => format!("({} :: Int)", parameter.value),
+            ParameterType::Float => format!("({} :: Double)", parameter.value),
+            ParameterType::Char => format!("('{}' :: Char)", parameter.value),
+            ParameterType::String => format!(r#"("{}" :: String)"#, parameter.value),
             ParameterType::Bool => {
                 let mut chars = parameter.value.chars();
                 match chars.next() {
                     None => unreachable!(""),
-                    Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+                    Some(c) => {
+                        format!(
+                            "({} :: Bool)",
+                            c.to_uppercase().collect::<String>() + chars.as_str()
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description
Introduces the new schema for types (specifying the precision on `int` and `float`).
It further cleans up the Bruno folder for endpoint testing in preparation for introducing a new language.

## Changes
- Specified in the documentation that `int` is a 64-bit signed integer, and that `float` is a double precision floating point value.
- Includes the type of each parameter during the formatting of parameters, this ensures that the `solution` boilerplate from the frontend has not seen a change in types.
- Fix test cases related to the above, both in terms of formatting, and solution related test cases (this also includes Bruno endpoints).
- Clean up the Bruno folder in preparation of Python being introduced as a supported language in the near future (a new issue will be created regarding this in the future).

## Additional Information
Any and all test cases that previously made use of the `float` type in some solution code very likely used the Haskell type `Float` which is no longer supported. These should all be changed to use the `Double` type instead.

## Checklist

- [x] I have added test cases for my additions
- [x] New and old tests passed
- [x] Documentation is updated
