### PR TITLE
Improve User Feedback

### DIFF
--- a/.bruno/Python/Syntax Error.bru
+++ b/.bruno/Python/Syntax Error.bru
@@ -1,0 +1,50 @@
+meta {
+  name: Syntax Error
+  type: http
+  seq: 4
+}
+
+post {
+  url: http://localhost:8080/submit
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "solution": "def solution(x: str)\n    return x.len()",
+    "testCases": [
+      {
+        "id": 0,
+        "inputParameters": [
+          {
+            "valueType": "string",
+            "value": ""
+          }
+        ],
+        "outputParameters": [
+          {
+            "valueType": "int",
+            "value": "0"
+          }
+        ]
+      },
+      {
+        "id": 1,
+        "inputParameters": [
+          {
+            "valueType": "string",
+            "value": "agurk"
+          }
+        ],
+        "outputParameters": [
+          {
+            "valueType": "int",
+            "value": "5"
+          }
+        ]
+      }
+    ]
+  }
+  
+}

--- a/docker/haskell/image.dockerfile
+++ b/docker/haskell/image.dockerfile
@@ -22,11 +22,6 @@ RUN setfacl -m u:restricted:r-x /usr
 RUN setfacl -m u:restricted:--- / 
 RUN setfacl -m u:restricted:--- /tmp
 RUN setfacl -m u:restricted:--- /var/tmp
-RUN setfacl -m u:restricted:--- /dev/shm
-RUN setfacl -m u:restricted:--- /var/spool/mail
-RUN setfacl -m u:restricted:--- /var/mail
-RUN setfacl -m u:restricted:--- /var/cache
-RUN setfacl -m u:restricted:--- /var/log
 
 ENV PATH="$PATH:/usr/bin/ghc"
 EXPOSE 8080

--- a/docker/haskell/test.dockerfile
+++ b/docker/haskell/test.dockerfile
@@ -15,11 +15,6 @@ RUN setfacl -m u:restricted:r-x /usr
 RUN setfacl -m u:restricted:--- / 
 RUN setfacl -m u:restricted:--- /tmp
 RUN setfacl -m u:restricted:--- /var/tmp
-RUN setfacl -m u:restricted:--- /dev/shm
-RUN setfacl -m u:restricted:--- /var/spool/mail
-RUN setfacl -m u:restricted:--- /var/mail
-RUN setfacl -m u:restricted:--- /var/cache
-RUN setfacl -m u:restricted:--- /var/log
 
 WORKDIR /test
 COPY . .

--- a/docker/python/image.dockerfile
+++ b/docker/python/image.dockerfile
@@ -20,11 +20,6 @@ RUN setfacl -m u:restricted:r-x /usr
 RUN setfacl -m u:restricted:--- / 
 RUN setfacl -m u:restricted:--- /tmp
 RUN setfacl -m u:restricted:--- /var/tmp
-RUN setfacl -m u:restricted:--- /dev/shm
-RUN setfacl -m u:restricted:--- /var/spool/mail
-RUN setfacl -m u:restricted:--- /var/mail
-RUN setfacl -m u:restricted:--- /var/cache
-RUN setfacl -m u:restricted:--- /var/log
 
 ENV PATH="$PATH:/usr/bin/python"
 EXPOSE 8080

--- a/docker/python/test.dockerfile
+++ b/docker/python/test.dockerfile
@@ -15,11 +15,6 @@ RUN setfacl -m u:restricted:r-x /usr
 RUN setfacl -m u:restricted:--- / 
 RUN setfacl -m u:restricted:--- /tmp
 RUN setfacl -m u:restricted:--- /var/tmp
-RUN setfacl -m u:restricted:--- /dev/shm
-RUN setfacl -m u:restricted:--- /var/spool/mail
-RUN setfacl -m u:restricted:--- /var/mail
-RUN setfacl -m u:restricted:--- /var/cache
-RUN setfacl -m u:restricted:--- /var/log
 
 WORKDIR /test
 COPY . .

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,4 +45,10 @@ pub enum SubmissionError {
     /// This error variant should NOT be stringified, instead it should be converted to a `[SubmissionResult::Failure]`.
     #[error("the submission did not pass all test cases")]
     Failure(Box<[TestCaseResult]>),
+
+    /// The execution process stopped due to an error.
+    ///
+    /// This could be things like syntax errors in interpretted languages.
+    #[error("an error occured during execution: {0}")]
+    Execution(String),
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -110,5 +110,5 @@ pub enum TestCaseFailureReason {
     },
 
     /// A runtime error occured during the test case.
-    RuntimeError,
+    RuntimeError(String),
 }

--- a/src/runner/haskell.rs
+++ b/src/runner/haskell.rs
@@ -19,6 +19,7 @@ module Main where
 import Solution
 import TestRunner
 import Control.Exception
+import Data.List
 
 main = do
 TEST_CASES
@@ -32,6 +33,14 @@ testChecker actual expected = do
   if actual == expected
     then putStrLn "p"
     else putStrLn ("f" ++ "," ++ show actual ++ "," ++ show expected)
+"###;
+
+/// The exception handling code snippet for Haskell.
+///
+/// The `TEST_CASE` is being replace with a call to the actual test case.
+/// This is done for all test cases.
+const HASKELL_EXCEPTION_SNIPPET: &str = r###"
+  catch (TEST_CASE) (\(e :: SomeException) -> putStrLn ("r" ++ "," ++ intercalate "\\n" (lines (show e))))
 "###;
 
 /// The language handler for Haskell.
@@ -155,9 +164,10 @@ impl LanguageHandler for Haskell {
                 .collect::<Vec<String>>()
                 .join(",");
 
-            let generated_test_case = format!(
-                "  catch (testChecker (solution {formatted_input_parameters}) ({formatted_output_parameters})) (\\(_ :: SomeException) -> putStrLn \"r\")"
+            let test_case = format!(
+                "testChecker (solution {formatted_input_parameters}) ({formatted_output_parameters})"
             );
+            let generated_test_case = HASKELL_EXCEPTION_SNIPPET.replace("TEST_CASE", &test_case);
             generated_test_cases.push(generated_test_case);
         }
 

--- a/src/runner/haskell.rs
+++ b/src/runner/haskell.rs
@@ -4,7 +4,7 @@ use super::LanguageHandler;
 use crate::{
     error::{SubmissionError, UUID_SHOULD_BE_VALID_STR},
     model::{Parameter, ParameterType, TestCase},
-    runner::TIMEOUT,
+    runner::{remove_mozart_path, TIMEOUT},
     timeout::timeout_process,
     RESTRICTED_USER_ID,
 };
@@ -86,10 +86,7 @@ impl Haskell {
             1 => {
                 info!("compile error");
                 let stderr = String::from_utf8_lossy(&compile_output.stderr);
-                let mut temp_dir = self.temp_dir.clone();
-                temp_dir.push("");
-                let path = temp_dir.to_str().expect(UUID_SHOULD_BE_VALID_STR);
-                let stripped = stderr.replace(path, "");
+                let stripped = remove_mozart_path(&stderr, self.temp_dir.clone());
 
                 debug!("compile error: {}", stripped);
                 return Err(SubmissionError::Compilation(stripped));
@@ -245,8 +242,10 @@ impl LanguageHandler for Haskell {
                 info!(?es);
                 info!("stdout: {}", String::from_utf8_lossy(&output.stdout));
                 info!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+                let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+                let stripped = remove_mozart_path(&stdout, self.temp_dir.clone());
 
-                Ok(String::from_utf8_lossy(&output.stdout).to_string())
+                Ok(stripped)
             }
             None => {
                 error!(

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -1,7 +1,7 @@
 //! Defines the components necessary for the language agnostic test runner to exist.
 
 use crate::{
-    error::SubmissionError,
+    error::{SubmissionError, UUID_SHOULD_BE_VALID_STR},
     model::{Parameter, Submission, TestCase, TestCaseFailureReason, TestCaseResult, TestResult},
 };
 use std::{fs::File, io::Write, path::PathBuf, time::Duration};
@@ -214,10 +214,16 @@ impl TestRunner {
                         }),
                     }
                 }
-                "r" => TestCaseResult {
-                    id: test_case.id,
-                    test_result: TestResult::Failure(TestCaseFailureReason::RuntimeError),
-                },
+                "r" => {
+                    let error = split.collect::<String>().replace("\\n", "\n");
+
+                    TestCaseResult {
+                        id: test_case.id,
+                        test_result: TestResult::Failure(TestCaseFailureReason::RuntimeError(
+                            error.to_string(),
+                        )),
+                    }
+                }
                 unknown => {
                     error!(
                         "unknown test outcome '{}' for test case '{}'",
@@ -323,7 +329,7 @@ mod parse_output_file {
 
     #[test]
     fn runtime_error_in_last_test_case() -> Result<(), SubmissionError> {
-        let test_output = ["p", "r"].join("\n");
+        let test_output = ["p", "r,did something bad"].join("\n");
         // the parameters are not necessary for this test, only the test case id
         let test_cases = [empty_test_case(0), empty_test_case(1)];
         let expected = Box::new([
@@ -333,7 +339,9 @@ mod parse_output_file {
             },
             TestCaseResult {
                 id: 1,
-                test_result: TestResult::Failure(TestCaseFailureReason::RuntimeError),
+                test_result: TestResult::Failure(TestCaseFailureReason::RuntimeError(
+                    String::from("did something bad"),
+                )),
             },
         ]);
 
@@ -346,7 +354,7 @@ mod parse_output_file {
 
     #[test]
     fn runtime_error_in_first_test_case() -> Result<(), SubmissionError> {
-        let test_output = ["r", "p", "p", "p", "p"].join("\n");
+        let test_output = ["r,not allowed", "p", "p", "p", "p"].join("\n");
         let test_cases = [
             empty_test_case(0),
             empty_test_case(1),
@@ -357,7 +365,9 @@ mod parse_output_file {
         let expected = Box::new([
             TestCaseResult {
                 id: 0,
-                test_result: TestResult::Failure(TestCaseFailureReason::RuntimeError),
+                test_result: TestResult::Failure(TestCaseFailureReason::RuntimeError(
+                    String::from("not allowed"),
+                )),
             },
             TestCaseResult {
                 id: 1,
@@ -552,7 +562,7 @@ mod parse_output_file {
 
     #[test]
     fn mixed_pass_and_failure_with_runtime_error() -> Result<(), SubmissionError> {
-        let test_output = ["p", "f,10,-10", "p", "r", "p"].join("\n");
+        let test_output = ["p", "f,10,-10", "p", "r,bad", "p"].join("\n");
         let test_cases = [
             TestCase {
                 id: 0,
@@ -632,7 +642,9 @@ mod parse_output_file {
             },
             TestCaseResult {
                 id: 3,
-                test_result: TestResult::Failure(TestCaseFailureReason::RuntimeError),
+                test_result: TestResult::Failure(TestCaseFailureReason::RuntimeError(
+                    String::from("bad"),
+                )),
             },
             TestCaseResult {
                 id: 4,

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -235,6 +235,13 @@ impl TestRunner {
     }
 }
 
+/// Removes the instances of the PathBuf p in s.
+fn remove_mozart_path(s: &str, mut p: PathBuf) -> String {
+    p.push("");
+    let path = p.to_str().expect(UUID_SHOULD_BE_VALID_STR);
+    s.replace(path, "")
+}
+
 #[cfg(test)]
 mod parse_output_file {
     use super::TestRunner;

--- a/src/runner/python.rs
+++ b/src/runner/python.rs
@@ -41,7 +41,7 @@ const PYTHON_EXCEPTION_SNIPPET: &str = r###"
     try:
         TEST_CASE
     except Exception as e:
-        print("r," + str(e))
+        print("r," + str(e).replace('\n', '\\n'))
 "###;
 
 /// The language handler for Python.

--- a/tests/submit/haskell.rs
+++ b/tests/submit/haskell.rs
@@ -1267,7 +1267,9 @@ async fn runtime_error_in_non_last_test_case() {
         },
         TestCaseResult {
             id: 1,
-            test_result: TestResult::Failure(TestCaseFailureReason::RuntimeError),
+            test_result: TestResult::Failure(TestCaseFailureReason::RuntimeError(String::from(
+                "divide by zero",
+            ))),
         },
         TestCaseResult {
             id: 2,
@@ -1417,7 +1419,9 @@ async fn mixed_pass_and_fail_with_runtime_error() {
         },
         TestCaseResult {
             id: 4,
-            test_result: TestResult::Failure(TestCaseFailureReason::RuntimeError),
+            test_result: TestResult::Failure(TestCaseFailureReason::RuntimeError(String::from(
+                "divide by zero",
+            ))),
         },
         TestCaseResult {
             id: 5,

--- a/tests/submit/python.rs
+++ b/tests/submit/python.rs
@@ -1043,7 +1043,9 @@ async fn runtime_error_in_non_last_test_case() {
         },
         TestCaseResult {
             id: 1,
-            test_result: TestResult::Failure(TestCaseFailureReason::RuntimeError),
+            test_result: TestResult::Failure(TestCaseFailureReason::RuntimeError(String::from(
+                "division by zero",
+            ))),
         },
         TestCaseResult {
             id: 2,
@@ -1192,7 +1194,9 @@ async fn mixed_pass_and_fail_with_runtime_error() {
         },
         TestCaseResult {
             id: 4,
-            test_result: TestResult::Failure(TestCaseFailureReason::RuntimeError),
+            test_result: TestResult::Failure(TestCaseFailureReason::RuntimeError(String::from(
+                "division by zero",
+            ))),
         },
         TestCaseResult {
             id: 5,
@@ -1252,7 +1256,9 @@ async fn create_file_in_mozart_directory() {
     let expected_status = StatusCode::OK;
     let expected_body = SubmissionResult::Failure(Box::new([TestCaseResult {
         id: 0,
-        test_result: TestResult::Failure(TestCaseFailureReason::RuntimeError),
+        test_result: TestResult::Failure(TestCaseFailureReason::RuntimeError(String::from(
+            "[Errno 13] Permission denied: '/mozart/my_file.txt'",
+        ))),
     }]));
 
     let actual = mozart
@@ -1307,7 +1313,9 @@ async fn create_file_in_tmp_directory() {
     let expected_status = StatusCode::OK;
     let expected_body = SubmissionResult::Failure(Box::new([TestCaseResult {
         id: 0,
-        test_result: TestResult::Failure(TestCaseFailureReason::RuntimeError),
+        test_result: TestResult::Failure(TestCaseFailureReason::RuntimeError(String::from(
+            "[Errno 13] Permission denied: '/tmp/my_file.txt'",
+        ))),
     }]));
 
     let actual = mozart
@@ -1362,7 +1370,9 @@ async fn create_file_in_var_tmp_directory() {
     let expected_status = StatusCode::OK;
     let expected_body = SubmissionResult::Failure(Box::new([TestCaseResult {
         id: 0,
-        test_result: TestResult::Failure(TestCaseFailureReason::RuntimeError),
+        test_result: TestResult::Failure(TestCaseFailureReason::RuntimeError(String::from(
+            "[Errno 13] Permission denied: '/var/tmp/my_file.txt'",
+        ))),
     }]));
 
     let actual = mozart


### PR DESCRIPTION
## Description
Correctly handles syntax errors in Python by providing the cause of the syntax error instead of an internal server error.

### Resolved Issue
Fixes #57
Closes #58 

## Changes
- Removes some niche writable directories from the dockerfiles. There is no way of knowing if the list was exhaustive in the first place, and some of the directories may not exist for certain builds, making the docker images less reproducible than what is intended.
- Applies an exit status check to the Python interpreter and provides the stderr output to the user if it exited unsuccessfully (before the timeout). This should allow the user to understand the cause of the error (i.e. the underlying syntax error).
- Adds a utility function for removing the 'mozart path' from strings, which is used to improve the error feedback in multiple scenarios + also hiding implementation details slightly from the end user, which should provide a better and safer experience.
- Makes Python and Haskell capture the cause of a runtime error (the underlying exception), which is included in the JSON output for a testcase, giving the end-user information feedback as to why a given test case ended up crashing. 

Look at the commit message + details for further information.

## Checklist

- [x] I have added test cases for my additions
- [x] New and old tests passed
- [x] Documentation is updated
